### PR TITLE
HACK: libcameraservice: Make system cameras available to all camera apps

### DIFF
--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -627,8 +627,7 @@ void CameraService::onTorchStatusChangedLocked(const String8& cameraId,
 }
 
 static bool hasPermissionsForSystemCamera(int callingPid, int callingUid) {
-    return checkPermission(sSystemCameraPermission, callingPid, callingUid) &&
-            checkPermission(sCameraPermission, callingPid, callingUid);
+    return checkPermission(sCameraPermission, callingPid, callingUid);
 }
 
 Status CameraService::getNumberOfCameras(int32_t type, int32_t* numCameras) {


### PR DESCRIPTION
* big brained realmeme decided to move aux cams to "system-only cameras"
utilizing the new permission introduced in android 11, thereby breaking
aux cams in 3rd party camera apps like gcam

* lets avoid this and make system camera accessible to all camera apps;
legacy apps still wont break because of the aux cams check in fwb